### PR TITLE
feat: Change project collection type to 'content'

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -38,7 +38,7 @@ const work = defineCollection({
 });
 
 const projects = defineCollection({
-  type: "data",
+  type: "content",
   schema: z.object({
     name: z.string(),
   }),


### PR DESCRIPTION
The project collection type is changed from 'data' to 'content' to better
reflect the nature of the content being managed. This change ensures that
the project information is treated as actual content rather than just
data, allowing for more robust content management and rendering within
the application.