### PR TITLE
feat(footer): simplify the footer component

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@astrojs/mdx": "^3.1.5",
     "@astrojs/react": "^3.6.2",
     "@astrojs/tailwind": "^5.1.0",
+    "@fontsource-variable/fira-code": "^5.1.0",
     "@fontsource-variable/inter": "^5.0.20",
     "@fontsource-variable/noto-serif": "^5.0.6",
     "@types/react": "^18.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@astrojs/tailwind':
         specifier: ^5.1.0
         version: 5.1.0(astro@4.15.4(rollup@4.21.2)(typescript@5.5.4))(tailwindcss@3.4.10)
+      '@fontsource-variable/fira-code':
+        specifier: ^5.1.0
+        version: 5.1.0
       '@fontsource-variable/inter':
         specifier: ^5.0.20
         version: 5.0.20
@@ -388,6 +391,9 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/fira-code@5.1.0':
+    resolution: {integrity: sha512-fwJbJLvyZ2BhgBSPYCNsrQ6IFQTpRu9GWXY8N20wHTpbhV0Ro5QJihiZV060Ay3kVR6IVH/oSVe/cr7Ube28gg==}
 
   '@fontsource-variable/inter@5.0.20':
     resolution: {integrity: sha512-dhzG4Zls/tIrf8h0FhTNi8jT/uFwNhdTY2vKe6DYqoXDYOfEcTVZDyh1hKml1rlLT44Y7OoKoGz8w7czDW7twQ==}
@@ -2729,6 +2735,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.21.5':
     optional: true
+
+  '@fontsource-variable/fira-code@5.1.0': {}
 
   '@fontsource-variable/inter@5.0.20': {}
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,14 +2,4 @@
 const year = new Date().getFullYear();
 ---
 
-<footer>
-    <div class="container mx-auto px-6 flex flex-col lg:flex-row gap-3 items-center uppercase text-sm font-light justify-between pb-4">
-        <nav class="flex items-center gap-3">
-            <a href="/">Home</a>
-            <a href="/">Work</a>
-            <a href="/">Projects</a>
-            <a href="/">Snippets</a>
-        </nav>
-        <p>&copy; {year} Gareth le Grange</p>
-    </div>
-</footer>
+<footer class="text-sm pb-3">&copy; {year} Gareth le Grange</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,22 +5,9 @@ const workTotal = (await getCollection("work")).length;
 const projectsTotal = (await getCollection("projects")).length;
 ---
 
-<header class="sticky lg:fixed top-4 left-0 right-0 mb-8">
-    <div class="container mx-auto px-6 flex gap-3 items-center uppercase">
-        <a href="/" class="flex flex-col text-pretty mr-auto">
-            <span class="font-semibold text-sm">Gareth le Grange</span>
-            <span class="font-light text-xs tracking-[0.012em]">Frontend developer</span>
-        </a>
-
-        <!-- <nav class="flex items-center gap-3">
-            <a href="/about" class="text-sm font-semibold">About</a>
-            <a href="/" class="text-sm font-semibold">Work<sup>({workTotal})</sup></a>
-            <a href="/" class="text-sm font-semibold">Projects<sup>({projectsTotal})</sup></a>
-            <a href="/" class="text-sm font-semibold">Snippets<sup>(12)</sup></a>
-        </nav> -->
-
-        <a href="mailto:garethlegrange+work@gmail.com" class="text-sm font-semibold border border-slate-900 rounded-full px-2 py-1.5 ml-4 leading-4 flex items-center">
-            <span>Contact me</span>
-        </a>
-    </div>
+<header class="pt-6">
+    <a href="/" class="flex flex-col">
+        <span class="font-semibold">Gareth le Grange</span>
+        <span class="text-sm tracking-[0.01em]">Frontend developer</span>
+    </a>
 </header>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,7 +1,6 @@
 ---
 import { ViewTransitions } from "astro:transitions";
-import "@fontsource-variable/inter";
-import '@fontsource-variable/noto-serif';
+import '@fontsource-variable/fira-code';
 import Header from "../components/Header.astro";
 import CTA from "../components/CallToAction.astro";
 import Footer from "../components/Footer.astro";
@@ -28,12 +27,15 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 		<link rel="canonical" href={canonicalURL} />
 		<ViewTransitions  />
 	</head>
-	<body class="bg-amber-50 text-slate-900 flex flex-col min-h-screen">
+	<body class="container mx-auto max-w-xl min-h-screen font-mono flex flex-col space-y-4 bg-amber-50">
 		<Header />
-		<main class="grow">
-			<slot />
+		<main class="grow flex flex-col space-y-3 [&_p]:text-sm">
+			<h1 class="font-semibold text-lg text-pretty">Hello, I'm Gareth &ndash; A Senior Frontend Developer passionate about crafting user-centric websites and applications.</h1>
+			<p>With over a decade of experience, I specialize in transforming complex ideas into sleek, high-performing websites and applications. Currently, I'm a Senior Frontend Developer at Webafrica, where I lead the development of innovative, user-friendly features, working remotely from the beautiful Muizenberg, South Africa.</p>
+			<p>I bring ideas to life using a suite of modern tools and technologies, including React, JavaScript, and CSS, to craft responsive and engaging user interfaces. My toolkit also includes TypeScript for type safety, Redux or Zustand for efficient state management, and Tailwind CSS for rapid, utility-first styling.</p>
+			<p>By integrating these tools with agile methodologies and staying current with industry trends, I create clean, maintainable code and collaborate effectively with cross-functional teams. This approach ensures that my solutions are not only functional and high-quality but also deliver exceptional user experiences.</p>
+			<p>I'm currently available for part-time freelance work. Feel free to reach out if you have a project in mind or want to discuss potential collaborations at <a href="mailto:garethlegrange+work@gmail.com" class="underline font-medium hover:no-underline">garethlegrange+work@gmail.com</a></p>
 		</main>
-		<CTA />
 		<Footer />
 	</body>
 </html>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -10,8 +10,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ["Inter Variable", ...defaultTheme.fontFamily.sans],
-        serif: ["Noto Serif Variable", ...defaultTheme.fontFamily.serif],
+        mono: ["Fira Code Variable", ...defaultTheme.fontFamily.mono],
       },
     },
   },


### PR DESCRIPTION
The changes made to the `Footer.astro` component simplify the footer by removing the navigation links and only displaying the copyright text. This decision was made to create a more minimalist and focused footer design, aligning with the overall aesthetic of the website.