### PR TITLE
feat: change contact link to email

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,7 +49,7 @@ import faceImage from "../images/face.webp";
 			</span>
 			<span>Book a meeting</span>
 		</a>
-		<a href="https://cal.com/garethlegrange" class="text-[clamp(12px,2vw,22px)] text-balance font-bold leading-none bg-transparent text-slate-900 border rounded-full py-4 px-6 flex space-x-2 items-center">
+		<a href="mailto:garethlegrange+work@gmail.com?subject=Work%20with%20me" class="text-[clamp(12px,2vw,22px)] text-balance font-bold leading-none bg-transparent text-slate-900 border rounded-full py-4 px-6 flex space-x-2 items-center">
 			<span>
 				<svg class="fill-slate-900" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#643341" viewBox="0 0 256 256"><path d="M224,48H32a8,8,0,0,0-8,8V192a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A8,8,0,0,0,224,48Zm-96,85.15L52.57,64H203.43ZM98.71,128,40,181.81V74.19Zm11.84,10.85,12,11.05a8,8,0,0,0,10.82,0l12-11.05,58,53.15H52.57ZM157.29,128,216,74.18V181.82Z"></path></svg>
 			</span>


### PR DESCRIPTION
Replaces the "Book a meeting" link with an email link to make it easier
for users to directly contact the author for work opportunities.
The email link is prefilled with a subject line of "Work with me" to
provide context to the recipient.