### PR TITLE
feat(Arcticle): add margin-top to article component

### DIFF
--- a/src/components/Arcticle.astro
+++ b/src/components/Arcticle.astro
@@ -1,6 +1,6 @@
 ---
 ---
 
-<article class="prose prose-neutral prose-a:no-underline">
+<article class="prose prose-neutral prose-a:no-underline mt-6">
     <slot />
 </article>


### PR DESCRIPTION
Adds a margin-top of 6 units to the article component to provide
more spacing between the article content and the surrounding
elements.